### PR TITLE
Force parser to consume entire input to detect trailing garbase.

### DIFF
--- a/src/main/antlr4/DecafParser.g4
+++ b/src/main/antlr4/DecafParser.g4
@@ -5,7 +5,7 @@ options { tokenVocab=DecafLexer; }
 // Classes and fields
 
 topLevel
-    : classDef*
+    : classDef* EOF
     ;
 
 classDef


### PR DESCRIPTION
ANTLR 默认不会消耗整个输入。

所以如果输入是 合法程序 + 末尾垃圾，ANTLR 不会对末尾垃圾报错。Java 版本和常理分析都会。